### PR TITLE
Adding a color for the checkbox

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ export default class CheckBox extends Component {
         checkedImage: React.PropTypes.element,
         unCheckedImage: React.PropTypes.element,
         onClick: React.PropTypes.func.isRequired,
-        isChecked: React.PropTypes.bool.isRequired
+        isChecked: React.PropTypes.bool.isRequired,
 	checkBoxColor: React.PropTypes.string,
     }
     static defaultProps = {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ export default class CheckBox extends Component {
         unCheckedImage: React.PropTypes.element,
         onClick: React.PropTypes.func.isRequired,
         isChecked: React.PropTypes.bool.isRequired
-
+	checkBoxColor: React.PropTypes.string,
     }
     static defaultProps = {
         isChecked: false,
@@ -65,7 +65,7 @@ export default class CheckBox extends Component {
         var source = this.props.isChecked ? require('./img/ic_check_box.png') : require('./img/ic_check_box_outline_blank.png');
 
         return (
-            <Image source={source}/>
+            <Image source={source} tintColor={this.props.checkBoxColor}/>
         );
     }
 


### PR DESCRIPTION
Users should be able to change the color of the default check box, in case they don't want to include new images in their source code.

Sample code snippet: 
```
<CheckBox onClick={this.onClick.bind(this)}
        isChecked={this.state.isSelected}
        checkBoxColor={'blue'}
        style={{alignSelf: 'center', position: 'absolute', right: 25}}/>
```