### PR TITLE
Remove deprecated proptypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ renderCheckBox(data) {
 
 Props              | Type     | Optional | Default     | Description
 ----------------- | -------- | -------- | ----------- | -----------
-style  | View.propTypes.style  | true |   |   Custom style checkbox
-leftText | React.PropTypes.string |true |   | Custom left Text
+style  | ViewPropTypes.style  | true |   |   Custom style checkbox
+leftText | PropTypes.string |true |   | Custom left Text
 leftTextStyle  |  Text.propTypes.style | true |  | Custom left Text style
-rightText | React.PropTypes.string |true |   | Custom right Text
-rightTextView | React.PropTypes.element | true |   | Custom right TextView
+rightText | PropTypes.string |true |   | Custom right Text
+rightTextView | PropTypes.element | true |   | Custom right TextView
 rightTextStyle  | Text.propTypes.style | true |  | Custom right Text style
-checkedImage  |  React.PropTypes.element  | true  | Default image | Custom  checked Image
-unCheckedImage  |  React.PropTypes.element  | true  |  Default image  | Custom  unchecked Image
-isChecked  |  React.PropTypes.bool |  false  |  false  | checkbox checked state
-onClick   |  React.PropTypes.func.isRequired |  false  |  | callback  function
+checkedImage  |  PropTypes.element  | true  | Default image | Custom  checked Image
+unCheckedImage  |  PropTypes.element  | true  |  Default image  | Custom  unchecked Image
+isChecked  |  PropTypes.bool |  false  |  false  | checkbox checked state
+onClick   |  PropTypes.func.isRequired |  false  |  | callback  function
 
 ## Contribution
 

--- a/index.js
+++ b/index.js
@@ -11,26 +11,28 @@ import React, {Component} from 'react';
 import {
     StyleSheet,
     View,
+    ViewPropTypes,
     Image,
     Text,
     TouchableHighlight
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 
 export default class CheckBox extends Component {
     static propTypes = {
-        ...View.propTypes,
-        leftText: React.PropTypes.string,
-        leftTextView: React.PropTypes.element,
-        rightText: React.PropTypes.string,
+        ...(ViewPropTypes || View.PropTypes),
+        leftText: PropTypes.string,
+        leftTextView: PropTypes.element,
+        rightText: PropTypes.string,
         leftTextStyle: Text.propTypes.style,
-        rightTextView: React.PropTypes.element,
+        rightTextView: PropTypes.element,
         rightTextStyle: Text.propTypes.style,
-        checkedImage: React.PropTypes.element,
-        unCheckedImage: React.PropTypes.element,
-        onClick: React.PropTypes.func.isRequired,
-        isChecked: React.PropTypes.bool.isRequired,
-	checkBoxColor: React.PropTypes.string,
+        checkedImage: PropTypes.element,
+        unCheckedImage: PropTypes.element,
+        onClick: PropTypes.func.isRequired,
+        isChecked: PropTypes.bool.isRequired,
+        checkBoxColor: PropTypes.string,
     }
     static defaultProps = {
         isChecked: false,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "bugs": {
     "url": "https://github.com/crazycodeboy/react-native-check-box/issues"
   },
+  "dependencies": {
+    "prop-types": "^15.5.7"
+  },
   "peerDependencies": {
     "react-native": ">=0.20.0"
   },


### PR DESCRIPTION
This should work with both react native <0.44 and 0.44+ and react 15 or 16

https://github.com/facebook/prop-types#how-to-depend-on-this-package

Closes #25 