### PR TITLE
Pass the `checkboxState` back to the caller

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,10 +58,11 @@ export default class CheckBox extends Component {
         return null;
     }
     onClick() {
+        const checkboxState = !this.state.isChecked;
         this.setState({
-            isChecked: !this.state.isChecked
+            isChecked: checkboxState
         })
-        this.props.onClick();
+        this.props.onClick(checkboxState);
     }
     _renderLeft() {
         if (this.props.leftTextView)return this.props.leftTextView;


### PR DESCRIPTION
When using a library like [react-native-form](https://www.npmjs.com/package/react-native-form) you need to have the `onClick` action return the current state for it to register as a form value.