### PR TITLE
Add testID to touchable opacity for testing frameworks

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ export default class CheckBox extends Component {
     }
     static propTypes = {
         ...(ViewPropTypes || View.PropTypes),
+        testID: PropTypes.string,
         leftText: PropTypes.string,
         leftTextView: PropTypes.element,
         rightText: PropTypes.string,
@@ -121,6 +122,7 @@ export default class CheckBox extends Component {
     render() {
         return (
             <TouchableHighlight
+                testID={this.props.testID}
                 style={this.props.style}
                 onPress={()=>this.onClick()}
                 underlayColor='transparent'


### PR DESCRIPTION
In our current project, we are using this component (thank you for your awesome contribution!! 🎉), we also need the ability to grab the icon via a testID, and our only solutions would be to fork your repo and maintain a separate copy, or just have this pr merged 🤞. Please consider merging! 👍 