### PR TITLE
Check if onClick is defined in props before executing

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ export default class CheckBox extends Component {
     }
 
     onClick() {
-        this.props.onClick();
+        const { onClick } = this.props;
+        onClick ? onClick() : null;
     }
 
     _renderLeft() {


### PR DESCRIPTION
This will prevent unnecessary crash if onClick is not defined in the props