### PR TITLE
fix: :bug: ViewPropTypes has been removed from React Native

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import {
     StyleSheet,
     View,
@@ -16,9 +16,10 @@ import {
     TouchableHighlight,
     ViewPropTypes as RNViewPropTypes,
 } from 'react-native';
+import { ViewPropTypes as DeprecatedViewPropTypes } from 'deprecated-react-native-prop-types'
 import PropTypes from 'prop-types';
 
-const ViewPropTypes = RNViewPropTypes || View.propTypes;
+const ViewPropTypes = DeprecatedViewPropTypes || RNViewPropTypes || View.propTypes;
 
 export default class CheckBox extends Component {
     constructor(props) {
@@ -111,7 +112,7 @@ export default class CheckBox extends Component {
         }
 
         return (
-            <Image source={source} style={{tintColor: this._getTintColor()}}/>
+            <Image source={source} style={{ tintColor: this._getTintColor() }} />
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "url": "https://github.com/crazycodeboy/react-native-check-box/issues"
   },
   "dependencies": {
-    "prop-types": "^15.5.7"
+    "prop-types": "^15.5.7",
+    "deprecated-react-native-prop-types": "^4.0.0"
   },
   "peerDependencies": {
     "react-native": ">=0.20.0"


### PR DESCRIPTION
Hello, I am submitting changes with the correction of the error related to this open issue:

[ViewPropTypes has been removed from React Native. Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types' #96](https://github.com/crazycodeboy/react-native-check-box/issues/96)

Best Regards!